### PR TITLE
fix: DO-1271 handle already-deleted secrets in absent state

### DIFF
--- a/plugins/modules/aws_secret.py
+++ b/plugins/modules/aws_secret.py
@@ -368,8 +368,10 @@ def main():
             elif current_secret.get("DeletedDate") and recovery_window == 0:
                 result = camel_dict_to_snake_dict(secrets_mgr.delete_secret(secret.name, recovery_window=recovery_window))
                 changed = True
+            else:
+                result = {"msg": "secret already marked for deletion"}
         else:
-            result = "secret does not exist"
+            result = {"msg": "secret does not exist"}
     if state == 'present':
         if current_secret is None:
             result = secrets_mgr.create_secret(secret)


### PR DESCRIPTION
Ensure the module always sets `result` when a secret is already marked for deletion or does not exist. Previously, this caused an UnboundLocalError due to `result` not being assigned in some cases. Now the module returns a consistent dictionary with a `msg` field for those scenarios.

Also improves consistency by always returning a dict instead of mixing strings and dicts.